### PR TITLE
change exercise name

### DIFF
--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -11,7 +11,7 @@ permissions:
   issues: write
 
 env:
-  EXERCISE_NAME: "Getting Started with GitHub Copilot"
+  EXERCISE_NAME: "Build Applications with GitHub Copilot Agent Mode"
   INTRO_MESSAGE: "Welcome to the exciting world of GitHub Copilot! 🚀 In this exercise, you'll unlock the potential of this AI-powered coding assistant to accelerate your development process. Let's dive in and have some fun exploring the future of coding together! 💻✨"
   STEP_1_FILE: ".github/steps/1-preparing.md"
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/0-start-exercise.yml` file. The change updates the `EXERCISE_NAME` environment variable to reflect a new exercise name.

* [`.github/workflows/0-start-exercise.yml`](diffhunk://#diff-391af7b32d36608157476690176e9511356d1dc7b17f7e2c596e0128cf485bc0L14-R14): Updated `EXERCISE_NAME` from "Getting Started with GitHub Copilot" to "Build Applications with GitHub Copilot Agent Mode".

