### PR TITLE
fix action

### DIFF
--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -156,13 +156,9 @@ jobs:
 
       - name: Build comment - add step content
         id: build-comment
-        uses: skills/action-text-variables@v1
-        with:
-          template-file: ${{ env.STEP_1_FILE }}
-          template-vars: |
-            login=${{ github.actor }}
-            full_repo_name=${{ github.repository }}
-
+        run: |
+          echo "updated-text=$(cat ${{ env.STEP_1_FILE }})" >> $GITHUB_OUTPUT
+      
       - name: Create comment - add step content
         run: |
           gh issue comment "$ISSUE_URL" \


### PR DESCRIPTION
This pull request includes a change to the `jobs:` section in the `.github/workflows/0-start-exercise.yml` file to update the method used for building comments. The most important change is the replacement of the `skills/action-text-variables@v1` action with a shell script that reads the content of `STEP_1_FILE` and sets it as an output variable.

* [`.github/workflows/0-start-exercise.yml`](diffhunk://#diff-391af7b32d36608157476690176e9511356d1dc7b17f7e2c596e0128cf485bc0L159-R160): Replaced the `skills/action-text-variables@v1` action with a shell script to read the content of `STEP_1_FILE` and set it as an output variable.