### PR TITLE
let changes to a variable

### DIFF
--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -160,7 +160,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
-            const core = require('@actions/core');
+            let core = require('@actions/core');
 
             const markdownFile = fs.readFileSync('.github/steps/1-preparing.md', 'utf8');
             core.exportVariable('MARKDOWN_CONTENT', markdownFile);


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/0-start-exercise.yml` file. The change modifies the declaration of the `core` variable from `const` to `let`.

* [`.github/workflows/0-start-exercise.yml`](diffhunk://#diff-391af7b32d36608157476690176e9511356d1dc7b17f7e2c596e0128cf485bc0L163-R163): Changed the `core` variable declaration from `const` to `let` to potentially allow reassignment.