### PR TITLE
add markdown to issue comment body

### DIFF
--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -154,28 +154,26 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email github-actions[bot]@users.noreply.github.com
 
-      - name: Create comment - add step content
+      - name: Read markdown file
+        id: read_markdown
+        run: |
+          content=$(cat .github/steps/1-preparing.md)
+          echo "file_content<<EOF" >> $GITHUB_ENV
+          echo "$content" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+          echo "issue_number=${{ github.event.issue.number }}" >> $GITHUB_ENV
+      
+      - name: Add comment to issue
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const fs = require('fs');
-            let core = require('@actions/core');
-
-            const markdownFile = fs.readFileSync('.github/steps/1-preparing.md', 'utf8');
-            core.exportVariable('MARKDOWN_CONTENT', markdownFile);
-
-            const { context, github } = require('@actions/github');
-
-            const issueNumber = context.issue.number;
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-
-            await github.rest.issues.createComment({
-              issue_number: issueNumber,
-              owner: owner,
-              repo: repo,
-              body: markdownFile
+            const issue_number = process.env.issue_number;
+            const body = process.env.file_content;
+            github.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body
             });
 
       # - name: Build comment - add step content


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow to improve the process of adding comments to issues. The changes involve reading the content of a markdown file and using it to create a comment on an issue.

Improvements to GitHub Actions workflow:

* [`.github/workflows/0-start-exercise.yml`](diffhunk://#diff-391af7b32d36608157476690176e9511356d1dc7b17f7e2c596e0128cf485bc0L157-R176): Added a step to read the content of a markdown file (`.github/steps/1-preparing.md`) and store it in environment variables. This content is then used in a subsequent step to create a comment on the issue using the GitHub Actions `github-script` action.